### PR TITLE
Trailing Semicolon Violation on print statement

### DIFF
--- a/SwiftNSURLSessionCodeGeneratorPlayground.playground/Contents.swift
+++ b/SwiftNSURLSessionCodeGeneratorPlayground.playground/Contents.swift
@@ -207,7 +207,7 @@ class MyRequestController {
             }
             else {
                 // Failure
-                print("URL Session Task Failed: %@", error!.localizedDescription);
+                print("URL Session Task Failed: %@", error!.localizedDescription)
             }
         })
         task.resume()


### PR DESCRIPTION
Swift doesn't require trailing semicolons as Objective-C does, therefore this shouldn't be there